### PR TITLE
Fix race condition with lambda event execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ services/codepipeline-deployment-notifications/.serverless
 .idea/
 
 # Local env vars
+.production-env
 .env
 
 # golang output binary directories

--- a/services/codepipeline-notifications/aws-codebuild-notifier/codebuild-notifier.go
+++ b/services/codepipeline-notifications/aws-codebuild-notifier/codebuild-notifier.go
@@ -9,43 +9,41 @@ import (
 
 // CodeBuildNotifier is the lambda handler invoked by the `lambda.Start` function call
 //
-func CodeBuildNotifier(event events.CodeBuildEvent) {
-	fmt.Println("### CodeBuildEvent")
-	fmt.Printf("\n### EventID: %s", event.ID)
-	fmt.Printf("\n### BuildID: %s", event.Detail.BuildID)
-	fmt.Println("EventFull:")
-	prettyJson, err := json.MarshalIndent(event, "", "    ")
+func CodeBuildNotifier(event events.SQSEvent) {
+
+	fmt.Println("EventRecord:")
+	prettyJson, err := json.MarshalIndent(event.Records[0], "", "    ")
 	if err != nil {
-		fmt.Println("## JSON Indent Error:")
+		fmt.Println("### JSON Indent Error:")
 		fmt.Println(err.Error())
 	}
 	fmt.Printf("\n%s", prettyJson)
 
+	var codebuildEvent events.CodeBuildEvent
+
+	// Take the escaped Json String of the Event from the SQS Event so we can use it
+	rawEscapedJsonString := []byte(event.Records[0].Body)
+	rawJsonBody := (*json.RawMessage)(&rawEscapedJsonString)
+
+	err = json.Unmarshal(*rawJsonBody, &codebuildEvent)
+	if err != nil {
+		fmt.Println("### JSON Unmarshal Error:")
+		fmt.Println(err.Error())
+	}
+
+	fmt.Println("## CodeBuildEvent")
+	fmt.Printf("\n## EventID: %s", codebuildEvent.ID)
+	fmt.Printf("\n## BuildID: %s", codebuildEvent.Detail.BuildID)
+
 	// The default should never get hit with the settings in the serverless.yml for CloudWatch detail types to listen to
 	// Useful for debugging and showing whats supported.
 	//
-	switch event.DetailType {
+	switch codebuildEvent.DetailType {
 	case events.CodeBuildStateChangeDetailType, events.CodeBuildPhaseChangeDetailType:
-		buildID := event.Detail.BuildID
-		BuildAndSendSlackMessage(event, buildID)
+		buildID := codebuildEvent.Detail.BuildID
+		BuildAndSendSlackMessage(codebuildEvent, buildID)
 	default:
 		fmt.Printf("\n# Non-Matched Event - Do nothing")
-	}
-}
-
-// Generic Error printer if exists - not much else we can do with them.
-//
-func HandleErrors(err error, event events.CodeBuildEvent) {
-	if err != nil {
-		fmt.Println("# Error:")
-		fmt.Println(err.Error())
-		fmt.Println("# Request:")
-		prettyJson, err := json.MarshalIndent(event, "", "    ")
-		if err != nil {
-			fmt.Println("# JSON Indent Error:")
-			fmt.Println(err.Error())
-		}
-		fmt.Printf("\n%s", prettyJson)
 	}
 }
 

--- a/services/codepipeline-notifications/aws-codebuild-notifier/codebuild-notifier_test.go
+++ b/services/codepipeline-notifications/aws-codebuild-notifier/codebuild-notifier_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/json"
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/stretchr/testify/require"
 	"io/ioutil"
@@ -12,8 +11,9 @@ func TestCodeBuildNotifier(t *testing.T) {
 	data, err := ioutil.ReadFile("../../../internal/test-data/codebuild-phase-change-notification.json")
 	require.NoError(t, err)
 
-	codeBuildEvent := events.CodeBuildEvent{}
-	json.Unmarshal(data, &codeBuildEvent)
+	message := events.SQSMessage{Body: string([]byte(data))}
 
-	CodeBuildNotifier(codeBuildEvent)
+	sqsEvent := events.SQSEvent{[]events.SQSMessage{message}}
+
+	CodeBuildNotifier(sqsEvent)
 }

--- a/services/codepipeline-notifications/aws-codepipeline-notifier/codepipeline-notifier_test.go
+++ b/services/codepipeline-notifications/aws-codepipeline-notifier/codepipeline-notifier_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"encoding/json"
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/stretchr/testify/require"
 	"io/ioutil"
@@ -12,8 +11,9 @@ func TestCodePipelineNotifier(t *testing.T) {
 	data, err := ioutil.ReadFile("../../../internal/test-data/codepipeline-action-execution-stage-change-event.json")
 	require.NoError(t, err)
 
-	codePipelineEvent := events.CodePipelineEvent{}
-	json.Unmarshal(data, &codePipelineEvent)
+	message := events.SQSMessage{Body: string([]byte(data))}
 
-	CodePipelineNotifier(codePipelineEvent)
+	sqsEvent := events.SQSEvent{[]events.SQSMessage{message}}
+
+	CodePipelineNotifier(sqsEvent)
 }

--- a/services/codepipeline-notifications/serverless.yml
+++ b/services/codepipeline-notifications/serverless.yml
@@ -1,17 +1,12 @@
 service: codepipeline-notifications
-#app: your-app-name
-#tenant: your-tenant-name
 
-# You can pin your service to only deploy with a specific Serverless version
-# Check out our docs for more details
-# frameworkVersion: "=X.X.X"
 frameworkVersion: '>=1.28.0 <2.0.0'
 
 provider:
   name: aws
   runtime: go1.x
-  stage: test
   region: ap-southeast-2
+  variableSyntax: "\\${((?!AWS)[ ~:a-zA-Z0-9._@'\",\\-\\/\\(\\)]+?)}" # Use this for allowing CloudFormation Pseudo-Parameters in your serverless.yml -- e.g. ${AWS::Region}. All other Serverless variables work as usual.
   iamRoleStatements:
     - Effect: Allow
       Action:
@@ -22,14 +17,44 @@ provider:
         - dynamodb:PutItem
         - dynamodb:UpdateItem
         - dynamodb:DeleteItem
-      Resource: "arn:aws:dynamodb:*:*:*" # TODO: Need to limit the use of this to the Table.
+      Resource:
+        Fn::Join:
+          - ':'
+          - - arn
+            - aws
+            - dynamodb
+            - Ref: AWS::Region
+            - Ref: AWS::AccountId
+            - 'table/aws-slack-notifications-message-ids'
     - Effect: Allow
       Action:
         - codepipeline:GetPipelineExecution
-      Resource: "arn:aws:codepipeline:*:*:*" # TODO: Do we need to limit this?
+      Resource:
+        Fn::Join:
+          - ':'
+          - - arn
+            - aws
+            - codepipeline
+            - Ref: AWS::Region
+            - Ref: AWS::AccountId
+            - '*' # Limited to Pipelines in the Account + Region Deployed.
+    - Effect: Allow
+      Action:
+        - sqs:ReceiveMessage
+        - sqs:DeleteMessage
+        - sqs:GetQueueAttributes
+      Resource:
+        Fn::Join:
+          - ':'
+          - - arn
+            - aws
+            - sqs
+            - Ref: AWS::Region
+            - Ref: AWS::AccountId
+            - 'aws-slack-notifications-codepipeline-notifications.fifo'
 
   environment:
-    DYNAMO_TABLE_NAME: slack-message-ids-${opt:stage, self:provider.stage}
+    DYNAMO_TABLE_NAME: aws-slack-notifications-message-ids
     AWS_SLACK_NOTIFICATIONS_OAUTH_ACCESS_TOKEN: ${env:AWS_SLACK_NOTIFICATIONS_OAUTH_ACCESS_TOKEN}
     CODEPIPELINE_DEPLOYMENT_NOTIFICATIONS_SLACK_CHANNEL: ${env:CODEPIPELINE_DEPLOYMENT_NOTIFICATIONS_SLACK_CHANNEL}
 
@@ -43,34 +68,91 @@ functions:
   codebuild-notifier:
     handler: bin/codebuild-notifier
     events:
-      - cloudwatchEvent:
-          name: "codebuild-slack-notifier"
+      - sqs:
+          arn:
+            Fn::Join:
+              - ':'
+              - - arn
+                - aws
+                - sqs
+                - Ref: AWS::Region
+                - Ref: AWS::AccountId
+                - 'aws-slack-notifications-codepipeline-notifications.fifo'
+          messageGroupId: 'codebuild-events'
+          batchSize: 1      # Only take 1 Message off at a time
           enabled: true
-          event:
-            source:
-              - "aws.codebuild"
-            detail-type:
-              - "CodeBuild Build State Change"
-              - "CodeBuild Build Phase Change"
+    reservedConcurrency: 1  # Only run 1 Lambda at a time.
   codepipeline-notifier:
     handler: bin/codepipeline-notifier
     events:
-      - cloudwatchEvent:
-          name: "codepipeline-slack-notifier"
-          enabled: true
-          event:
-            source:
-              - "aws.codepipeline"
-            detail-type:
-              - "CodePipeline Pipeline Execution State Change"
-              - "CodePipeline Action Execution State Change"
-              - "CodePipeline Stage Execution State Change"
-
+      - sqs:
+          arn:
+            Fn::Join:
+              - ':'
+              - - arn
+                - aws
+                - sqs
+                - Ref: AWS::Region
+                - Ref: AWS::AccountId
+                - 'aws-slack-notifications-codepipeline-notifications.fifo'
+          messageGroupId: 'codepipeline-events'
+          batchSize: 1        # Only take 1 message off at a time
+    reservedConcurrency: 1  # Only run 1 Lambda at a time.
 resources:
   Resources:
-    NewResource:
+    CloudWatchCodePipelineEventQueue:
+      Type: AWS::SQS::Queue
+      Properties:
+        FifoQueue: true
+        ContentBasedDeduplication: true # Required for CloudWatchEvents to be sent to this Queue as it is Fifo
+        QueueName: 'aws-slack-notifications-codepipeline-notifications.fifo'
+    CloudWatchCodePipelineEventRule:
+      DependsOn: CloudWatchCodePipelineEventQueue
+      Type: AWS::Events::Rule
+      Properties:
+        EventPattern:
+          source:
+            - aws.codepipeline
+          detail-type:
+            - "CodePipeline Pipeline Execution State Change"
+            - "CodePipeline Action Execution State Change"
+            - "CodePipeline Stage Execution State Change"
+        Targets:
+          - Arn:
+              Fn::Join:
+                - ':'
+                - - arn
+                  - aws
+                  - sqs
+                  - Ref: AWS::Region
+                  - Ref: AWS::AccountId
+                  - 'aws-slack-notifications-codepipeline-notifications.fifo'
+            Id: 'cloudwatch-codepipeline-event-queue'
+            SqsParameters: { MessageGroupId: 'codepipeline-events' }
+    CloudWatchCodeBuildEventRule:
+      DependsOn: CloudWatchCodePipelineEventQueue
+      Type: AWS::Events::Rule
+      Properties:
+        EventPattern:
+          source:
+            - aws.codebuild
+          detail-type:
+            - "CodeBuild Build State Change"
+            - "CodeBuild Build Phase Change"
+        Targets:
+          - Arn:
+              Fn::Join:
+                - ':'
+                - - 'arn'
+                  - 'aws'
+                  - 'sqs'
+                  - Ref: AWS::Region
+                  - Ref: AWS::AccountId
+                  - 'aws-slack-notifications-codepipeline-notifications.fifo'
+            Id: 'cloudwatch-codepipeline-event-queue'
+            SqsParameters: { MessageGroupId: 'codebuild-events' }
+    SlackMessageIdTable:
       Type: AWS::DynamoDB::Table
-      DeletionPolicy: Retain
       Properties:
         AttributeDefinitions:
           - AttributeName: buildID
@@ -79,4 +161,4 @@ resources:
           - AttributeName: buildID
             KeyType: HASH
         BillingMode: PAY_PER_REQUEST
-        TableName: 'slack-message-ids-${opt:stage, self:provider.stage}'
+        TableName: 'aws-slack-notifications-message-ids'


### PR DESCRIPTION
* Use SQS (FIFO Queue) to take CloudWatch Events before triggering
  limited 1 concurrency lambda to make sure events are executed in
  order

Note: CloudWatch events still doesn't guarantee these are written to
      SQS in the order they occur. Have noticed that the Pipeline
      events can come after the Build in some instances but still
      much cleaner in general then before.